### PR TITLE
[IMP] sale_stock: stock.move name should rely on po line name if defined

### DIFF
--- a/addons/sale_stock/models/stock.py
+++ b/addons/sale_stock/models/stock.py
@@ -92,7 +92,7 @@ class StockPicking(models.Model):
             product = move.product_id
             so_line_vals = {
                 'move_ids': [(4, move.id, 0)],
-                'name': product.display_name,
+                'name': move.purchase_line_id and move.purchase_line_id.name or product.display_name,
                 'order_id': sale_order.id,
                 'product_id': product.id,
                 'product_uom_qty': 0,


### PR DESCRIPTION
The process of confirming the outgoing delivery will create new sale lines in the original sale order. If it is related to a purchase order, the newly created sale order line should reference the purchase order first, instead of using the product name.